### PR TITLE
Bump product-api to 0.17 to support TProxy

### DIFF
--- a/hashicups/product-api.yaml
+++ b/hashicups/product-api.yaml
@@ -69,7 +69,7 @@ spec:
             path: conf.json
       containers:
         - name: product-api
-          image: hashicorpdemoapp/product-api:v0.0.11
+          image: hashicorpdemoapp/product-api:v0.0.17
           ports:
             - containerPort: 9090
             - containerPort: 9103


### PR DESCRIPTION
product-api:v0.0.11 does not support TProxy and attempts to hit the envoy proxy directly